### PR TITLE
ci: Build on tag

### DIFF
--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -45,6 +45,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "hugo/v*"
     paths:
       - "archetypes/**"
       - "content/**"
@@ -52,7 +54,9 @@ on:
       - "i18n/**"
       - "static/**"
       - "hugo.yml"
-      - ".github/workflows/test-hugo-build.yml"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/hugo-build.yml"
 
 jobs:
   build-hugo-root:

--- a/.github/workflows/hugo-release.yml
+++ b/.github/workflows/hugo-release.yml
@@ -1,0 +1,72 @@
+---
+name: Hugo release
+
+on:
+  push:
+    tags:
+      - "hugo/v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. hugo/v1.2.3)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide tag
+        id: pick
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Find latest build artifact for tag
+        id: run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.pick.outputs.tag }}
+        run: |
+          set -Eeuo pipefail
+
+          run_id="$(gh api "repos/${REPO}/actions/workflows/hugo-build.yml/runs?status=success&per_page=20" --jq '.workflow_runs[] | select(.head_branch == env.TAG) | .id' | head -n 1)"
+
+          if [ -z "$run_id" ]; then
+            echo "No successful build run found for tag $TAG"
+            exit 1
+          fi
+
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: hugo-site
+          run-id: ${{ steps.run.outputs.run-id }}
+          github-token: ${{ github.token }}
+          path: ./_published
+
+      - name: Create release and upload asset
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.pick.outputs.tag }}
+          name: ${{ steps.pick.outputs.tag }}
+          files: ./_published/**
+          draft: false
+          prerelease: false

--- a/.github/workflows/hugo-tag.yml
+++ b/.github/workflows/hugo-tag.yml
@@ -1,0 +1,62 @@
+---
+name: Hugo tag release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".version"
+      - ".bumpversion.toml"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (for manual escape hatch, e.g. 1.2.3)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version
+        id: v
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="$(tr -d '[:space:]' < .version)"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=hugo/v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          tag="${{ steps.v.outputs.tag }}"
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "[INFO] Tag exists: $tag"
+            exit 0
+          fi
+
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
Add workflow to create tag when .version file changes.

Tag creation triggers build, which triggers release.

Release uses release asset artifact now instead of pipeline artifact.